### PR TITLE
fix makepkg compile error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ else
 	python ./$(PKGNAME).py -i ./$(PKGNAME).csv -o $(PKGNAME).txt --no-mini
 endif
 
-$(PKGNAME).index $(PKGNAME).dict.dz: $(PKGNAME).txt
+$(PKGNAME).index $(PKGNAME).dict.dz &: $(PKGNAME).txt
 	dictfmt --utf8 --allchars -s ECDICT -u $(URL) -j $(PKGNAME) < ./$(PKGNAME).txt && dictzip $(PKGNAME).dict
 
 install: $(PKGNAME).index $(PKGNAME).dict.dz


### PR DESCRIPTION
we should append “&” for targets .index .dict.dz，for it's generated same time, or the command will be called twice and the latter would failed when makepkg with "dictzip (main): Cannot unlink ecdict.dict"